### PR TITLE
Make tests match the output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ func (t *testSuite) TestEquality() {
   t.Equal("awesome", "awesome")
 }
 
+//failing test
+func (t *testSuite) TestInequality() {
+	t.NotEqual("awesome", "awesome")
+}
 ~~~
 
 Then, to run the tests simply use the the go test command:


### PR DESCRIPTION
I am sorry about the previous pull request, it doesn't have a matching test output for the test input which might confuse users. Here is a corrected version. 

Thanks
