### PR TITLE
Fixed panic when suiteInfo.callerName does not contain the package

### DIFF
--- a/prettytest.go
+++ b/prettytest.go
@@ -262,12 +262,7 @@ func (formatter *BDDFormatter) splitString(text, sep string) (result string) {
 	}
 
 	stringWithUnderscores := s[len(s)-1]
-	splittedByUnderscores := strings.Split(stringWithUnderscores, "_")
-
-	for _, v := range splittedByUnderscores {
-		result += v + " "
-	}
-	return strings.TrimSpace(result)
+	return strings.Replace(stringWithUnderscores, "_", " ", -1)
 }
 
 func (s *Suite) SetT(t *testing.T)          { s.T = t }


### PR DESCRIPTION
Hi, firstly thanks for creating this! I found it quite useful for setting up BDD in Go.

I found an issue when using the BDD formatter, closely related to issue #5.

The callerName can be in two formats: 

```
com/remogatto/prettytest.(*testSuite).Should_be_cool
```

or 

```
(*testSuite).Should_be_cool
```

Currently only the first case was handled and the second caused a panic in `BDDFormatter.splitString`:

```
BDD Formatter:
panic: runtime error: index out of range [recovered]
    panic: runtime error: index out of range

goroutine 4 [running]:
testing._func_003(0xb7594fd4, 0xb7594100, 0xb7594fdc)
    /usr/lib/go/src/pkg/testing/testing.go:268 +0x11f
----- stack segment boundary -----
_/home/hari/prog/prettytest.(*BDDFormatter).splitString(0x18666ce0, 0x1864e2c0, 0x39, 0x8100f0c, 0x1, ...)
    /home/hari/prog/prettytest/prettytest.go:264 +0xa4
```

I've attached commits which provide support for both callerName formats.

Thanks!
pranav
