### PR TITLE
Forcing suite.Not() to be on an Assertion instead of a bool so that it can't be misused

### DIFF
--- a/prettytest_test.go
+++ b/prettytest_test.go
@@ -49,6 +49,7 @@ func (suite *testSuite) TestFailMessage() {
 
 func (suite *testSuite) TestTrue() {
 	suite.True(true)
+	suite.Not(suite.True(false))
 }
 
 func (suite *testSuite) TestError() {
@@ -59,6 +60,11 @@ func (suite *testSuite) TestError() {
 func (suite *testSuite) TestNot() {
 	suite.Not(suite.Equal("foo", "bar"))
 	suite.Not(suite.True(false))
+}
+
+func (suite *testSuite) TestFalse() {
+	suite.False(false)
+	suite.Not(suite.False(true))
 }
 
 func (suite *testSuite) TestEqual() {


### PR DESCRIPTION
implemented type checking so that suite.Not can't be used on non-Assertions
implemented suite.False again because I missed it when it went away :)  I just think t.False(false) is more clear/succinct than t.Not(t.True(false))
